### PR TITLE
Offer both a :cmdline and :dark-mode org block options

### DIFF
--- a/pikchr-mode.el
+++ b/pikchr-mode.el
@@ -225,7 +225,10 @@ the block contents as BODY and its header argumenst as PARAMS."
       (insert body))
     (org-babel-eval
      (concat (org-babel-process-file-name pikchr-executable)
-             " --svg-only " (org-babel-process-file-name in-file))
+             " --svg-only "
+             (when (assq :dark-mode params) "--dark-mode ")
+             (when (assq :cmdline params) (cdr (assq :cmdline params)))
+             (org-babel-process-file-name in-file))
      "")))
 
 (defun org-babel-prep-session:pikchr (_session _params)


### PR DESCRIPTION
To generate a dark version of pikchr images, this commit allows the following:

    #+begin_src pikchr :file foobar.svg :dark-mode
     ...
    #+end_src

This addresses Issue #1 